### PR TITLE
Fix link to documentation link, select read-only

### DIFF
--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -2,7 +2,7 @@
 Email sensor support.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.email/
+https://home-assistant.io/components/sensor.imap_email_content/
 """
 import logging
 import datetime
@@ -97,7 +97,7 @@ class EmailReader:
         """Read the next email from the email server."""
         import imaplib
         try:
-            self.connection.select()
+            self.connection.select('Inbox', readonly=True)
 
             if not self._unread_ids:
                 search = "SINCE {0:%d-%b-%Y}".format(datetime.date.today())


### PR DESCRIPTION
## Description:

- Fixed link to documentation page at the top of the sensor
- Select the IMAP4 Inbox read-only so that reading e-mail does not mark messages as Read

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.